### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -65,9 +65,11 @@ jobs:
 
       - name: Comment PR with test results
         uses: actions/github-script@v9
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           script: |
-            const branchName = "${{ github.event.workflow_run.head_branch }}";
+            const branchName = process.env.HEAD_BRANCH;
 
             // Find PRs associated with this branch
             const { data: pulls } = await github.rest.pulls.list({


### PR DESCRIPTION
Potential fix for [https://github.com/Roberdvs/devops-showcase-app/security/code-scanning/1](https://github.com/Roberdvs/devops-showcase-app/security/code-scanning/1)

Use an intermediate environment variable for the untrusted value and read it via `process.env` inside the script, instead of injecting `${{ ... }}` directly into JavaScript source.

Best fix in this file:
- In the `Comment PR with test results` step (`.github/workflows/e2e-tests.yaml`, around lines 66–111), add:
  - `env:`
  - `HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}`
- Replace line 70:
  - from `const branchName = "${{ github.event.workflow_run.head_branch }}";`
  - to `const branchName = process.env.HEAD_BRANCH;`

This preserves behavior while removing script-time expression injection risk. No functional logic changes otherwise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->