### PR TITLE
ci: categorize releases by conventional PR titles and enforce them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -13,18 +16,30 @@ updates:
       opentelemetry:
         patterns:
           - "opentelemetry-*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: "helm"
     directory: "/helm/devops-showcase-app"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,59 +1,75 @@
 name-template: 'v$RESOLVED_VERSION 🚀'
 tag-template: '$RESOLVED_VERSION'
 
+# Unified category pipeline (release-drafter 7.4+). A `when` given as a list
+# is OR — the PR matches the category if any condition object matches;
+# predicates inside one condition object are AND.
+#
+# Categorization matches conventional PR titles directly (enforced by the
+# pr-title workflow); labels remain as manual overrides.
+#
+# `exclusive: true` = first-match-wins: a PR lands only in the first matching
+# category, instead of being rendered in every category it matches.
 categories:
+  # Ordered before New so `feat!:` lands here, not in New.
   - title: '🔥 Breaking Changes'
     semver-increment: 'major'
+    exclusive: true
     when:
-      labels:
-        - 'breaking-change'
+      - labels:
+          - 'breaking-change'
+      - conventional:
+          breaking: true
   - title: '🎉 New'
     semver-increment: 'minor'
+    exclusive: true
     when:
-      labels:
-        - 'feature'
-        - 'enhancement'
-  - title: '🐛 Fixes'
-    semver-increment: 'patch'
-    when:
-      labels:
-        - 'bug'
+      - labels:
+          - 'feature'
+          - 'enhancement'
+      - conventional:
+          type: 'feat'
+  # Ordered before Fixes and Maintenance so Dependabot's `chore(deps): ...`
+  # titles and `dependencies` label (applied by Dependabot itself) win over
+  # the bare `fix`/`chore` type matches below.
   - title: '📦 Dependency Updates'
     semver-increment: 'patch'
+    exclusive: true
     when:
-      labels:
-        - 'dependencies'
+      - labels:
+          - 'dependencies'
+      - conventional:
+          scopes:
+            - 'deps'
+            - 'deps-dev'
+  - title: '🐛 Fixes'
+    semver-increment: 'patch'
+    exclusive: true
+    when:
+      - labels:
+          - 'bug'
+      - conventional:
+          type: 'fix'
   - title: '🔧 Maintenance'
     semver-increment: 'patch'
+    exclusive: true
     when:
-      labels:
-        - 'chore'
-        - 'internal'
-        - 'maintenance'
+      - labels:
+          - 'chore'
+          - 'internal'
+          - 'maintenance'
+      - conventional:
+          types:
+            - 'chore'
+            - 'ci'
+            - 'build'
+            - 'docs'
+            - 'refactor'
+            - 'style'
+            - 'test'
+            - 'perf'
+            - 'revert'
+  # Fallback bucket for changes that match no category above (no `when`)
   - title: 'Other Changes'
-
-autolabeler:
-  - label: 'breaking-change'
-    branch:
-      - '/breaking\/.+/'
-    title:
-      - '(?i)^breaking.*'
-  - label: 'feature'
-    branch:
-      - '/feat\/.+/'
-    title:
-      - '(?i)^feat.*'
-  - label: 'bug'
-    branch:
-      - '/fix\/.+/'
-    title:
-      - '(?i)^fix.*'
-  - label: 'dependencies'
-    branch:
-      - '/dependabot\/.+/'
-      - '/renovate\/.+/'
-  - label: 'chore'
-    branch:
-      - '/chore\/.+/'
 
 template: "$CHANGES"

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,27 @@
+name: PR Title
+
+# Enforces conventional PR titles (feat/fix/chore/... per the Conventional
+# Commits spec). Release-drafter categorizes changes and resolves the next
+# version from these titles — see .github/release-drafter.yml.
+#
+# pull_request_target (not pull_request) so the check also runs with a valid
+# token on PRs from forks; the action only reads PR metadata and never checks
+# out or executes PR code, so this is safe.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-  # pull_request event is required for autolabeler
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:
-    if: github.event_name == 'push'
     permissions:
       contents: write
       pull-requests: read
@@ -19,12 +15,3 @@ jobs:
       - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
         with:
           commitish: main
-
-  autolabel:
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7


### PR DESCRIPTION
Same treatment as scilifeio/infrastructure#2156, adapted for Dependabot.

## What

- **`.github/release-drafter.yml`**: each category now ORs its label match with a conventional-title condition (release-drafter ≥ 7.4, already pinned at the 7.7.0 SHA):
  - `feat!:` / `BREAKING CHANGE` → 🔥 Breaking Changes (major) — previously `feat!:` only got the `feature` label and bumped minor
  - `feat` → 🎉 New (minor), `fix` → 🐛 Fixes (patch)
  - `deps`/`deps-dev` scopes or the `dependencies` label → 📦 Dependency Updates, ordered above Fixes/Maintenance so the scoped match wins over the bare types
  - `chore`, `ci`, `build`, `docs`, `refactor`, `style`, `test`, `perf`, `revert` → 🔧 Maintenance (the lint action's full default type set, so nothing that passes the check falls into Other Changes)
  - `exclusive: true` everywhere (first-match-wins) so a PR matching several categories isn't rendered in each of them
  - The autolabeler is gone: Dependabot applies the `dependencies` label itself by default, categorization no longer needs the other labels, and the old `(?i)^feat.*` inline-flag title matchers never fired anyway (release-drafter only honors `/pattern/flags` literals). Labels remain as manual overrides.
- **`.github/workflows/release-drafter.yaml`**: the `autolabel` job and its `pull_request` trigger are removed — one fewer workflow run on every PR open/reopen/synchronize. Also drops the mismatched second action SHA that job used.
- **`.github/dependabot.yml`**: explicit `commit-message: prefix: "chore", include: "scope"` on every ecosystem, so PR titles arrive as `chore(deps): ...` and match the Dependency Updates category by title as well as by label.
- **`.github/workflows/pr-title.yaml`** (new): enforces conventional PR titles via [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request), SHA-pinned to v6.1.1. `pull_request_target` with read-only permissions — it never checks out PR code, so it's fork-safe.

## Notes

- Recent history is already effectively conventional (`chore: Bump ...`), so enforcement shouldn't block anything that's flowing today.
- The title check won't run on this PR itself (`pull_request_target` uses the workflow from `main`); it takes effect on the next PR after merge. To make it blocking, add `Validate conventional PR title` as a required status check once it has run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request titles are now validated against Conventional Commits standards.
  * Release notes are automatically categorized using labels and commit information, with priority handling for breaking and dependency changes.
* **Chores**
  * Automated dependency updates now use consistent commit-message formatting.
  * Release drafting is streamlined to run after changes reach the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->